### PR TITLE
add go modules. use context from stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sasha-s/go-csync
+
+go 1.16

--- a/mutex.go
+++ b/mutex.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 	"sync/atomic"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Mutex is a context-aware mutual exclusion lock.

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
+	"sync/atomic"
 )
-import "sync/atomic"
 
 func TestMutexPanic(t *testing.T) {
 	defer func() {


### PR DESCRIPTION
- use context instead of golang.org/x/net/context.
- use modules

Closes #2 